### PR TITLE
Add neovim diagnostic highlights

### DIFF
--- a/colors/zengarden.vim
+++ b/colors/zengarden.vim
@@ -657,6 +657,16 @@ endif
 
 " }}}
 
+" Diagnostics: {{{
+
+hi! link DiagnosticError ZengardenRed
+hi! link DiagnosticWarn ZengardenOrange
+hi! link DiagnosticInfo ZengardenYellow
+hi! link DiagnosticHint ZengardenBlue
+hi! link DiagnosticOk ZengardenGreen
+
+" }}}
+
 " Plugin specific -------------------------------------------------------------
 " EasyMotion: {{{
 
@@ -877,10 +887,10 @@ hi! link CocErrorFloat ZengardenRed
 hi! link CocWarningFloat ZengardenOrange
 hi! link CocInfoFloat ZengardenYellow
 hi! link CocHintFloat ZengardenBlue
-hi! link CocDiagnosticsError ZengardenRed
-hi! link CocDiagnosticsWarning ZengardenOrange
-hi! link CocDiagnosticsInfo ZengardenYellow
-hi! link CocDiagnosticsHint ZengardenBlue
+hi! link CocDiagnosticsError DiagnosticError
+hi! link CocDiagnosticsWarning DiagnosticWarn
+hi! link CocDiagnosticsInfo DiagnosticInfo
+hi! link CocDiagnosticsHint DiagnosticHint
 
 hi! link CocSelectedText ZengardenRed
 hi! link CocCodeLens ZengardenGray


### PR DESCRIPTION
Link the `Diagnostic*` highlight groups of neovim (see :help diagnostic-highlights) to get more pleasant/readable colours there.  For comparison, the top of the screenshot shows the main branch (without my changes), bottom shows the branch of this PR:

![image](https://github.com/tobi-wan-kenobi/zengarden/assets/9333121/b120aa8b-bae7-4488-bfc6-d7cc1f694ef5)

I took the colours from the `CocDiagnostics*` links below and changed it there to link to the `Diagnostic*` groups, so there are no redundant definitions.  (Disclaimer: I don't use CoC so not sure where/how exactly they are used but I hope it makes sense like this?)

Does the place in the file where I added this make sense?  If not, I'm happy to move it to a more fitting location.

Note: I don't have a setup to properly test with Vim (i.e. the non-neo one).  I hope this change won't break anything there?